### PR TITLE
fix(security): patch 3 high-severity vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1439,9 +1439,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9047,9 +9047,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
-      "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10681,9 +10681,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
Update hono (4.12.x → patched), @hono/node-server (<1.19.10 → patched), and minimatch (10.0.0-10.2.2 → patched) to resolve:
- GHSA-xh87-mx6m-69f3: auth bypass via IP spoofing in Hono
- GHSA-5pq2-9x2x-5p6w: cookie attribute injection in Hono setCookie()
- GHSA-p6xx-57qc-3wxr: SSE control field injection in Hono writeSSE()
- GHSA-q5qw-h33p-qvwr: arbitrary file access via serveStatic in Hono
- GHSA-wc8c-qw6v-h7f6: auth bypass for static paths in @hono/node-server
- GHSA-7r86-cg39-jmmj: ReDoS in minimatch matchOne()
- GHSA-23c5-xmqv-rm74: ReDoS in minimatch extglobs

Remaining: dompurify >=3.1.3 (moderate, XSS via GHSA-v2wj-7wpq-c8vv). No patched version available yet — monitor for release >3.3.1.